### PR TITLE
feat: Implement reactive saving and fix deletion bug

### DIFF
--- a/Scores.html
+++ b/Scores.html
@@ -481,9 +481,11 @@
       else alert(name?'Ce nom existe déjà':'Entre un nom, hein !');
     });
 
-    document.getElementById('scoreForm').addEventListener('submit',e=>{
-      e.preventDefault();
+    // Lit les valeurs du formulaire de score et sauvegarde
+    function saveScoreFromForm() {
       const name = document.getElementById('groupName').value;
+      if (!name) return; // Ne rien faire si aucun groupe n'est chargé
+
       const data = {
         capitaineUsed:   document.querySelector('input[name="capitaineUsed"]:checked').value === 'true',
         voyanteCards:    +document.getElementById('voyanteCards').value,
@@ -492,24 +494,31 @@
         ritualErrors:    +document.getElementById('ritualErrors').value,
         voleurCorrected: document.querySelector('input[name="voleurCorrected"]:checked').value === 'true'
       };
-      updateGroupScore(name,data);
+      updateGroupScore(name, data);
+    }
+
+    // Le formulaire sauvegarde à chaque changement
+    document.getElementById('scoreForm').addEventListener('change', saveScoreFromForm);
+
+    document.getElementById('scoreForm').addEventListener('submit',e=>{
+      e.preventDefault();
+      saveScoreFromForm(); // Sauvegarde finale avant de fermer
       e.target.reset();
-      document.querySelectorAll('.time-buttons button').forEach(b=>b.classList.remove('active'));
+      // Nettoyage des boutons actifs et valeurs cachées
+      document.querySelectorAll('.time-buttons button, .voyante-buttons button, .ritual-buttons button')
+        .forEach(b => b.classList.remove('active'));
       document.getElementById('treasureTime').value = 0;
+      document.getElementById('voyanteCards').value = 0;
+      document.getElementById('ritualErrors').value = 0;
       closeModal(scoreModal);
     });
 
     document.getElementById('confirmDeleteBtn').addEventListener('click', () => {
       if (window.groupToDelete) {
         deleteGroup(window.groupToDelete);
-        window.groupToDelete = null;
+        window.groupToDelete = null; // Important de nettoyer
       }
-
-      // Fermeture manuelle de la modale
-      const modal = document.getElementById('confirmDeleteModal');
-      modal.classList.remove('active');
-      modal.style.opacity = 0;
-      modal.style.pointerEvents = 'none';
+      closeModal(confirmDeleteModal); // Utilise la fonction standardisée
     });
 
     // Gestion des boutons de temps
@@ -521,6 +530,7 @@
           b.classList.remove('active')
         );
         button.classList.add('active');
+        saveScoreFromForm(); // Sauvegarde réactive
       });
     });
 
@@ -533,6 +543,7 @@
           b.classList.remove('active')
         );
         button.classList.add('active');
+        saveScoreFromForm(); // Sauvegarde réactive
       });
     });
 
@@ -545,6 +556,7 @@
           b.classList.remove('active')
         );
         button.classList.add('active');
+        saveScoreFromForm(); // Sauvegarde réactive
       });
     });
 


### PR DESCRIPTION
This commit introduces two main improvements to the Scores page:

1.  **Reactive Score Saving:** The score form is now fully reactive. Any change made to a group's score details—such as using a power, adjusting time, or selecting a ritual outcome—is now saved automatically. This is achieved by triggering a save function on every input change, removing the need to manually click the save button to record interim changes.

2.  **Deletion Bug Fix:** A bug that prevented the deletion of multiple groups without a page refresh has been resolved. The issue was caused by the confirmation modal not closing correctly. The code has been updated to use the standardized `closeModal` function, ensuring the modal closes properly and allows for consecutive deletions.