### PR TITLE
Fix: Close delete modal and add group features

### DIFF
--- a/Scores.html
+++ b/Scores.html
@@ -334,10 +334,26 @@
     const BASE_SCORE = 50, MAX_BASE = 50;
 
     // Ajout, suppression, mise à jour
+    function generatePassword() {
+      const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+      let password = '';
+      for (let i = 0; i < 6; i++) {
+        password += chars.charAt(Math.floor(Math.random() * chars.length));
+      }
+      return password;
+    }
+
     function addGroup(name) {
       if (!name || groups[name]) return false;
-      groups[name] = { status:'En cours', score:null, data:null, details:null };
-      renderGroupList(); saveToGitHub(groups);
+      groups[name] = {
+        status: 'En cours',
+        score: null,
+        data: null,
+        details: null,
+        password: generatePassword()
+      };
+      renderGroupList();
+      saveToGitHub(groups);
       return true;
     }
     function deleteGroup(name) {
@@ -373,10 +389,12 @@
         li.className = classes.join(' ');
         li.innerHTML = `
           <div style="display:flex;justify-content:space-between;">
-            <span>${name}</span>
+            <span>${name}
+              <small>(${g.password})</small>
+            </span>
             <span class="status-badge ${
-              g.status==='En cours'?'status-in-progress':
-              g.status==='Terminé'?'status-completed':'status-error'
+              g.status === 'En cours' ? 'status-in-progress' :
+              g.status === 'Terminé' ? 'status-completed' : 'status-error'
             }">${g.status}</span>
           </div>
           <div style="display:flex;justify-content:space-between;margin-top:8px;">
@@ -387,6 +405,7 @@
             ${g.status==='Terminé'?`<button class="btn" data-group="${name}">Résultat</button>`:''}
           </div>
           <div class="group-actions">
+            <a href="groupe.html?name=${encodeURIComponent(name)}" target="_blank" class="btn">Page du Groupe</a>
             <button class="btn btn-danger" data-group="${name}" data-action="delete">Supprimer</button>
           </div>
         `;
@@ -404,7 +423,7 @@
           openModal(scoreModal);
         })
       );
-      document.querySelectorAll('.btn-danger').forEach(btn=>
+      document.querySelectorAll('.group-item .btn-danger').forEach(btn=>
         btn.addEventListener('click',e=>{
           window.groupToDelete = e.target.dataset.group;
           openModal(confirmDeleteModal);
@@ -513,12 +532,14 @@
       closeModal(scoreModal);
     });
 
-    document.getElementById('confirmDeleteBtn').addEventListener('click', () => {
+    document.getElementById('confirmDeleteBtn').addEventListener('click', (e) => {
+      e.stopPropagation(); // Prevent any other listeners from firing
       if (window.groupToDelete) {
         deleteGroup(window.groupToDelete);
         window.groupToDelete = null; // Important de nettoyer
       }
-      closeModal(confirmDeleteModal); // Utilise la fonction standardisée
+      // Always close the modal after the action is complete
+      closeModal(confirmDeleteModal);
     });
 
     // Gestion des boutons de temps

--- a/groupe.html
+++ b/groupe.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <title>Page du Groupe</title>
+  <style>
+    body { font-family: 'Segoe UI', sans-serif; text-align: center; padding-top: 50px; }
+    #login, #content { max-width: 400px; margin: 0 auto; padding: 20px; border: 1px solid #ccc; border-radius: 8px; }
+    #content { display: none; }
+    input { width: calc(100% - 20px); padding: 10px; margin-bottom: 10px; }
+    button { padding: 10px 20px; cursor: pointer; }
+  </style>
+</head>
+<body>
+  <div id="login">
+    <h1 id="groupName"></h1>
+    <input type="password" id="password" placeholder="Mot de passe">
+    <button id="submitPassword">Entrer</button>
+    <p id="error" style="color:red;"></p>
+  </div>
+
+  <div id="content">
+    <h2>Bienvenue, <span id="welcomeGroupName"></span>!</h2>
+    <p>Cette page est en construction.</p>
+  </div>
+
+  <script>
+    document.addEventListener('DOMContentLoaded', async () => {
+      const params = new URLSearchParams(window.location.search);
+      const groupName = params.get('name');
+      const groupNameH1 = document.getElementById('groupName');
+      const welcomeGroupNameSpan = document.getElementById('welcomeGroupName');
+
+      if (!groupName) {
+        document.body.innerHTML = '<h1>Aucun groupe spécifié.</h1>';
+        return;
+      }
+
+      groupNameH1.textContent = `Groupe: ${groupName}`;
+      welcomeGroupNameSpan.textContent = groupName;
+
+      const passwordInput = document.getElementById('password');
+      const submitButton = document.getElementById('submitPassword');
+      const errorP = document.getElementById('error');
+
+      submitButton.addEventListener('click', async () => {
+        try {
+          const apiUrl = 'https://api.github.com/repos/Zhaal/un-loup-garou-a-eu/contents/scores-loup-garou.json';
+          const response = await fetch(`${apiUrl}?ref=main`, {
+            headers: { 'Accept': 'application/vnd.github.v3.raw' },
+            cache: 'no-store'
+          });
+          if (!response.ok) throw new Error('Could not fetch group data.');
+
+          const groups = await response.json();
+          const groupData = groups[groupName];
+
+          if (groupData && passwordInput.value === groupData.password) {
+            document.getElementById('login').style.display = 'none';
+            document.getElementById('content').style.display = 'block';
+          } else {
+            errorP.textContent = 'Mot de passe incorrect.';
+          }
+        } catch (err) {
+          errorP.textContent = `Erreur: ${err.message}`;
+        }
+      });
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
This commit addresses several issues:

- Fixes a bug where the delete confirmation modal would not close after a group was deleted.
- Implements a new feature to automatically generate a 6-character password for each new group.
- Displays the generated password next to the group's name on the main scores page.
- Creates a new, dedicated page for each group (`groupe.html`) that is password-protected.
- Adds a link from the scores page to each group's dedicated page.