### PR TITLE
The `saveScores` Netlify function was not specifying a branch when wr…

### DIFF
--- a/netlify/functions/saveScores.js
+++ b/netlify/functions/saveScores.js
@@ -9,6 +9,7 @@ exports.handler = async (event) => {
     const owner = 'Zhaal';              // ton user GitHub
     const repo  = 'un-loup-garou-a-eu'; // ton dépôt
     const path  = 'scores-loup-garou.json';
+    const branch = 'main'; // On s'assure de bosser sur la branche principale
 
     // Encodage du JSON envoyé depuis la page
     const content = Buffer.from(event.body).toString('base64');
@@ -16,7 +17,7 @@ exports.handler = async (event) => {
 
     // Si le fichier existe déjà, on récupère son SHA
     try {
-      const { data } = await octo.repos.getContent({ owner, repo, path });
+      const { data } = await octo.repos.getContent({ owner, repo, path, branch });
       sha = data.sha;
     } catch (e) {
       // fichier absent => sha reste undefined
@@ -24,7 +25,7 @@ exports.handler = async (event) => {
 
     // Création ou mise à jour du fichier
     await octo.repos.createOrUpdateFileContents({
-      owner, repo, path,
+      owner, repo, path, branch,
       message: 'Mise à jour des scores via Netlify Function',
       content, sha,
     });


### PR DESCRIPTION
…iting to the GitHub repository. This could cause the scores file to be saved to a different branch than the one the player page (`joueur.html`) reads from, leading to groups not appearing.

This change explicitly sets the target branch to `main` in the Netlify function for both reading the file's SHA and writing the new content. This ensures that the scores are always saved to the correct location.