### PR TITLE
feat: Optimize save system to reduce requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Local Netlify folder
+.netlify

--- a/Esprit.html
+++ b/Esprit.html
@@ -198,22 +198,15 @@
         }
 
         async function recordReplay() {
-            saveStatus.textContent = 'Enregistrement de la relecture...';
             try {
-                const allGroups = await getGroupsData();
-                const group = allGroups[groupName];
-                if (!group) throw new Error('Groupe non trouvé.');
+                const replayKey = `replay_${groupName}_${spiritId}`;
+                const currentReplays = parseInt(sessionStorage.getItem(replayKey) || '0', 10);
+                sessionStorage.setItem(replayKey, currentReplays + 1);
 
-                if (!group.data) group.data = {};
-                if (!group.data.replays) group.data.replays = 0;
-
-                group.data.replays++;
-
-                await saveGroupsData(allGroups);
-                alert('Relecture enregistrée. Les points seront déduits dans le tableau des scores.');
-                saveStatus.textContent = 'Relecture enregistrée.';
+                alert('Relecture enregistrée. Elle sera comptabilisée lors de la soumission de la réponse.');
+                saveStatus.textContent = 'Relecture notée.';
             } catch (err) {
-                alert(`Erreur lors de l\'enregistrement de la relecture: ${err.message}`);
+                alert(`Erreur lors de l'enregistrement local de la relecture: ${err.message}`);
                 console.error(err);
                 saveStatus.textContent = `Erreur.`;
             }
@@ -226,10 +219,29 @@
 
             if (!group.data) group.data = {};
             if (!group.data.enigmaAnswers) group.data.enigmaAnswers = {};
+            if (!group.data.replays) group.data.replays = {};
 
+            // Mettre à jour la réponse à l'énigme
             group.data.enigmaAnswers[spiritId] = answer;
 
+            // Collecter les relectures pour ce groupe depuis sessionStorage
+            const spiritIds = ['A', 'B', 'C', 'D'];
+            spiritIds.forEach(sId => {
+                const replayKey = `replay_${groupName}_${sId}`;
+                const replayCount = parseInt(sessionStorage.getItem(replayKey) || '0', 10);
+                if (replayCount > 0) {
+                    group.data.replays[sId] = (group.data.replays[sId] || 0) + replayCount;
+                    // On supprime la clé pour ne pas la recompter plus tard
+                    sessionStorage.removeItem(replayKey);
+                }
+            });
+
             await saveGroupsData(allGroups);
+
+            // Notifier la page des scores pour qu'elle se rafraîchisse
+            const updateChannel = new BroadcastChannel('scores_update');
+            updateChannel.postMessage('refresh');
+            updateChannel.close();
         }
     });
     </script>

--- a/Scores.html
+++ b/Scores.html
@@ -437,16 +437,19 @@
       groups[name].status = newStatus;
       renderGroupList(); // optimistic update
 
-      isSaving = true;
-      try {
-        await saveToGitHub(groups);
-      } catch (err) {
-        alert(`❌ Échec de la mise à jour du statut: ${err.message}`);
-        // Rollback
-        groups[name].status = oldStatus;
-        renderGroupList();
-      } finally {
-        isSaving = false;
+      // Sauvegarde uniquement si le statut passe à "Terminé"
+      if (newStatus === 'Terminé') {
+        isSaving = true;
+        try {
+          await saveToGitHub(groups);
+        } catch (err) {
+          alert(`❌ Échec de la mise à jour du statut: ${err.message}`);
+          // Rollback
+          groups[name].status = oldStatus;
+          renderGroupList();
+        } finally {
+          isSaving = false;
+        }
       }
     }
     async function updateGroupScore(name, data) {
@@ -740,9 +743,6 @@
       await updateGroupScore(name, data);
     }
 
-    // Le formulaire sauvegarde à chaque changement pour une UX réactive
-    document.getElementById('scoreForm').addEventListener('change', saveScoreFromForm);
-
     document.getElementById('scoreForm').addEventListener('submit', async e => {
       e.preventDefault();
 
@@ -852,7 +852,16 @@
     });
 
     // Lancement de l'actualisation
-    setInterval(loadFromGitHub, 5000);
+    // setInterval(loadFromGitHub, 5000);
+
+    // Écoute des mises à jour depuis d'autres pages
+    const updateChannel = new BroadcastChannel('scores_update');
+    updateChannel.onmessage = (event) => {
+      if (event.data === 'refresh') {
+        console.log('🔄 Mise à jour reçue, chargement des données...');
+        loadFromGitHub();
+      }
+    };
   </script>
 </body>
 </html>


### PR DESCRIPTION
This commit optimizes the application's save functionality to reduce the number of API calls to the backend.

- The continuous polling (`setInterval`) on the Scores page has been removed and replaced with a `BroadcastChannel` to listen for updates from other pages.
- Saves are now triggered only on specific user actions:
  - Group creation and deletion.
  - Changing a group's status to "Terminé".
  - Submitting the results form on the "Scores" page.
  - Submitting an enigma answer on the "Esprit" page.
- Replay counts on the "Esprit" page are now stored in `sessionStorage` and are only saved to the backend when an enigma answer is submitted, preventing a save on every replay.