### PR TITLE
Refactor: Pre-fill enigma answers and disable buttons

### DIFF
--- a/groupe.html
+++ b/groupe.html
@@ -95,13 +95,18 @@
           const groupData = allGroups[groupName];
 
           if (groupData && groupData.data && groupData.data.enigmaAnswers) {
-            for (const spiritId in spiritCodes) {
-              if (groupData.data.enigmaAnswers[spiritId]) {
+            for (const spiritId in groupData.data.enigmaAnswers) {
+              const answer = groupData.data.enigmaAnswers[spiritId];
+              if (answer) {
+                const form = document.getElementById(`form${spiritId}`);
+                const input = document.getElementById(`code${spiritId}`);
+                const button = form.querySelector('button');
                 const enigmaAlert = document.getElementById(`enigma${spiritId}`);
-                const isAcknowledged = localStorage.getItem(`enigmaAcknowledged_${groupName}_${spiritId}`);
 
-                if (enigmaAlert && !isAcknowledged) {
-                  enigmaAlert.style.display = 'inline';
+                input.value = answer;
+                button.disabled = true;
+                if (enigmaAlert) {
+                  enigmaAlert.style.display = 'none';
                 }
               }
             }


### PR DESCRIPTION
This commit modifies the `groupe.html` page to improve the user experience for players who have already solved an enigma.

Previously, the page only showed an alert for solved enigmas. Now, the `checkEnigmas` function has been updated to:
- Pre-fill the input field with the player's saved answer.
- Disable the corresponding 'Rencontrer' button to prevent re-submission.
- Hide the enigma alert, as it is no longer needed.

This change makes it clearer to players which enigmas they have already completed.