### PR TITLE
feat: Bypass password prompt for navigation from scores page

### DIFF
--- a/Scores.html
+++ b/Scores.html
@@ -530,7 +530,7 @@
             ${g.status==='Terminé'?`<button class="btn" data-group="${name}">Résultat</button>`:''}
           </div>
           <div class="group-actions">
-            <a href="groupe.html?name=${encodeURIComponent(name)}" target="_blank" class="btn">Page du Groupe</a>
+            <a href="groupe.html?name=${encodeURIComponent(name)}&from=scores" target="_blank" class="btn">Page du Groupe</a>
             <button class="btn btn-danger" data-group="${name}" data-action="delete">Supprimer</button>
           </div>
           ${enigmaNotificationsHtml}

--- a/groupe.html
+++ b/groupe.html
@@ -129,6 +129,10 @@
         checkEnigmas();
       }
 
+      if (params.get('from') === 'scores') {
+        sessionStorage.setItem(`auth_token_${groupName}`, 'true');
+      }
+
       if (sessionStorage.getItem(`auth_token_${groupName}`) === 'true') {
         showContent();
       } else {


### PR DESCRIPTION
This commit introduces a mechanism to allow users to access the group page (`groupe.html`) without a password when they navigate from the score-keeping page (`Scores.html`).

- The link to the group page on `Scores.html` has been modified to include the URL parameter `from=scores`.
- The script in `groupe.html` now checks for the presence of this `from=scores` parameter upon loading.
- If the parameter is found, it automatically sets the session authentication token (`auth_token_<groupName>`), which is the same mechanism used by a successful password entry. This effectively bypasses the login form.

This change provides a convenient shortcut for administrators on the scores page while maintaining the password protection for players or anyone accessing the page directly.