### PR TITLE
Feat: Add 15s timer and auto-refresh to group page

### DIFF
--- a/Scores.html
+++ b/Scores.html
@@ -658,9 +658,9 @@
 
     const updateChannel = new BroadcastChannel('scores_update');
     updateChannel.onmessage = (event) => {
-      if (event.data === 'refresh') {
-        console.log('🔄 Mise à jour reçue, chargement des données...');
-        loadFromGitHub();
+      if (event.data === 'refresh' || event.data === 'reload') {
+        console.log('🔄 Mise à jour reçue, rechargement de la page...');
+        location.reload();
       }
     };
   </script>

--- a/groupe.html
+++ b/groupe.html
@@ -110,6 +110,7 @@
     </div>
     <p id="spiritError" class="error-message"></p>
     <a href="joueur.html" style="margin-top: 30px; display: inline-block;">Changer de groupe</a>
+    <div id="timer" style="text-align: center; margin-top: 20px; font-size: 1.5em; color: white; background-color: red; padding: 10px;"></div>
   </div>
 
   <script>
@@ -165,6 +166,23 @@
         loginContainer.classList.add('hidden');
         contentContainer.classList.remove('hidden');
         checkEnigmas();
+
+        // Start the 15-second countdown timer
+        let timeLeft = 15;
+        const timerElement = document.getElementById('timer');
+        const updateChannel = new BroadcastChannel('scores_update');
+
+        const timerInterval = setInterval(() => {
+          if (timeLeft <= 0) {
+            clearInterval(timerInterval);
+            timerElement.textContent = 'Redirection...';
+            updateChannel.postMessage('reload'); // Notify other pages to reload
+            window.location.href = 'joueur.html'; // Redirect to the player page
+          } else {
+            timerElement.textContent = `Redirection vers la page joueur dans ${timeLeft} secondes.`;
+            timeLeft--;
+          }
+        }, 1000);
       }
 
       async function checkEnigmas() {

--- a/joueur.html
+++ b/joueur.html
@@ -81,6 +81,15 @@
 
       // Charger les groupes au chargement de la page
       loadGroups();
+
+      // Listen for reload messages from other pages
+      const updateChannel = new BroadcastChannel('scores_update');
+      updateChannel.onmessage = (event) => {
+        if (event.data === 'reload') {
+          console.log('Reload message received, refreshing the page.');
+          location.reload();
+        }
+      };
     });
   </script>
 


### PR DESCRIPTION
This commit introduces a 15-second countdown timer on the `groupe.html` page.

When the timer expires:
- The user is redirected from `groupe.html` to `joueur.html`.
- A 'reload' message is broadcast to other open pages using a BroadcastChannel.
- The `joueur.html` and `Scores.html` pages now listen for this 'reload' message and automatically refresh themselves to ensure their content is up-to-date.

This addresses the user's request to have the player and scores pages refresh automatically after the group page timer finishes.